### PR TITLE
Fixed package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * multiple sort by user (with Shift key pressed)
 
 # usage
-* change source for import Table from 'antd' to 'antd-ext-table'
+* change source for import Table from 'antd' to 'antd-table-ext'
 * ... profit! 
 
 # restrictions


### PR DESCRIPTION
Seems like a typo:

- `antd-ext-table` does **not exist**: https://www.npmjs.com/package/antd-ext-table
- `antd-table-ext` exists and is this library: https://www.npmjs.com/package/antd-table-ext